### PR TITLE
Tree initialization

### DIFF
--- a/config/defaults.cfg
+++ b/config/defaults.cfg
@@ -1,32 +1,6 @@
 // these default settings get executed whenever "config.cfg" is not available
 // do not modify anything below, instead change settings in game, or add to autoexec.cfg
 
-name "unnamed"
-
-invmouse 0         // 1 for flightsim mode
-sensitivity 3      // similar number to quake
-fov 100            // 90 is default in other games
-hudgun 1
-
-musicvol 60       // set higher if you want (max 255)
-soundvol 255      // sounds average volume is actually set per sound, average 100
-
-gamma 100          // set to your liking, 100 = default
-
-fullbrightmodels 60 // make player models a bit easier to see
-
-fullscreen 1
-
-// console
-
-consize 5            // console is 5 lines
-miniconsize 5        // mini-console is 5 lines
-miniconwidth 40      // mini-console is 40% of screen width
-fullconsize 75       // full console is 75% of screen height
-miniconfilter 0x300  // display chat and team chat in mini-console
-confilter (&~ 0x2FFF $miniconfilter) // don't display other player frags or mini-console stuff in console
-fullconfilter 0xFFFF // display all messages in full console
-
 // Move binds
 
 bind W forward


### PR DESCRIPTION
Removed some default settings which are provided by the Inexor Tree initialization.

It's important to remove the default settings because these values overwrites the tree values